### PR TITLE
Making grus buildable with alpha_grus.mk instead of lineage_grus.mk

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -5,9 +5,9 @@
 #
 
 PRODUCT_MAKEFILES := \
-    $(LOCAL_DIR)/lineage_grus.mk
+    $(LOCAL_DIR)/alpha_grus.mk
 
 COMMON_LUNCH_CHOICES := \
-    lineage_grus-user \
-    lineage_grus-userdebug \
-    lineage_grus-eng
+    alpha_grus-user \
+    alpha_grus-userdebug \
+    alpha_grus-eng

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -109,7 +109,7 @@ BOARD_SUPER_PARTITION_CUST_DEVICE_SIZE := 1073741824
 BOARD_SUPER_PARTITION_METADATA_DEVICE := system
 
 # Partitions - reserved size
--include vendor/lineage/config/BoardConfigReservedSize.mk
+-include vendor/alpha/config/BoardConfigReservedSize.mk
 $(foreach p, $(call to-upper, $(TREBLE_PARTITIONS)), \
     $(eval BOARD_$(p)IMAGE_PARTITION_RESERVED_SIZE := 30720000))
 
@@ -143,7 +143,7 @@ VENDOR_SECURITY_PATCH := $(PLATFORM_SECURITY_PATCH)
 # Sepolicy
 TARGET_USES_LOGDUMP_AS_METADATA := true
 include device/qcom/sepolicy_vndr/SEPolicy.mk
-include device/lineage/sepolicy/libperfmgr/sepolicy.mk
+include device/alpha/sepolicy/libperfmgr/sepolicy.mk
 SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += $(DEVICE_PATH)/sepolicy/private
 SYSTEM_EXT_PUBLIC_SEPOLICY_DIRS += $(DEVICE_PATH)/sepolicy/public
 BOARD_VENDOR_SEPOLICY_DIRS += $(DEVICE_PATH)/sepolicy/vendor
@@ -165,7 +165,7 @@ DEVICE_FRAMEWORK_COMPATIBILITY_MATRIX_FILE := \
     hardware/qcom-caf/common/vendor_framework_compatibility_matrix.xml \
     hardware/qcom-caf/common/vendor_framework_compatibility_matrix_legacy.xml \
     hardware/xiaomi/vintf/xiaomi_framework_compatibility_matrix.xml \
-    vendor/lineage/config/device_framework_matrix.xml
+    vendor/alpha/config/device_framework_matrix.xml
 
 # VNDK
 BOARD_VNDK_VERSION := current

--- a/alpha_grus.mk
+++ b/alpha_grus.mk
@@ -8,11 +8,11 @@
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base_telephony.mk)
 
-# Inherit some common Lineage stuff.
-$(call inherit-product, vendor/lineage/config/common_full_phone.mk)
-
 # Inherit from grus device
 $(call inherit-product, device/xiaomi/grus/device.mk)
+
+# Inherit some common Lineage stuff.
+$(call inherit-product, vendor/alpha/config/common_full_phone.mk)
 
 PRODUCT_NAME := lineage_grus
 PRODUCT_DEVICE := grus
@@ -38,7 +38,7 @@ TARGET_BUILD_PACKAGE := 2
 # 1 - stock (default)
 # 2 - lawnchair
 # 3 - pixel (valid only on gapps builds)
-TARGET_LAUNCHER := 2
+TARGET_LAUNCHER := 1
 
 # GAPPS (valid only for GAPPS builds)
 TARGET_SUPPORTS_QUICK_TAP := true
@@ -48,7 +48,7 @@ TARGET_INCLUDE_LIVE_WALLPAPERS := false
 # TARGET_SUPPORTS_GOOGLE_RECORDER := true
 
 # Debugging
-TARGET_INCLUDE_MATLOG := false
+TARGET_INCLUDE_MATLOG := true
 
 # Maintainer
 ALPHA_BUILD_TYPE := Official

--- a/device.mk
+++ b/device.mk
@@ -479,7 +479,7 @@ PRODUCT_PACKAGES += \
     libpng.vendor \
     libwfdaac_vendor
 
-PRODUCT_BOOT_JARS += \
+# PRODUCT_BOOT_JARS += \
     WfdCommon
 
 # dummy app to override unwanted packages


### PR DESCRIPTION
Making grus buildable with alpha_grus.mk instead of lineage_grus.mk